### PR TITLE
Updated powerbroker config files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Support for RedHat and Suse is included but has not been tested.
 
 Please open a pull request with any changes or bugfixes.
 
-### overriding / using params.pp
+## Overriding / using params.pp
 
 e.g. puppet/hiera/hieradata/common.yaml
         ...

--- a/README.md
+++ b/README.md
@@ -79,10 +79,12 @@ Please open a pull request with any changes or bugfixes.
 ## Overriding / using params.pp
 
 e.g. puppet/hiera/hieradata/common.yaml
+```
         ...
         pbis::nss_enumeration_enabled: true|false  
         pbis::cache_expiry: '86400'   # 1 day cache expiry
         ...
+```
 
 ## History
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ Support for RedHat and Suse is included but has not been tested.
 
 Please open a pull request with any changes or bugfixes.
 
+### overriding / using params.pp
+
+e.g. puppet/hiera/hieradata/common.yaml
+        ...
+        pbis::nss_enumeration_enabled: true|false  
+        pbis::cache_expiry: '86400'   # 1 day cache expiry
+        ...
+
 ## History
 
 Likewise Open was acquired by BeyondTrust in 2011 and rebranded as PowerBroker Identity Services Open Edition. The project page is at [powerbrokeropen.org](http://www.powerbrokeropen.org).

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,6 +20,8 @@ class pbis (
   $require_membership_of = $pbis::params::require_membership_of,
   $skeleton_dirs         = $pbis::params::skeleton_dirs,
   $user_domain_prefix    = $pbis::params::user_domain_prefix,
+  $nss_enumeration_enabled  = $pbis::params::nss_enumeration_enabled,
+  $cache_expiry             = $pbis::params::cache_expiry,
   $use_repository        = $pbis::params::use_repository,
   ) inherits pbis::params {
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,6 +22,8 @@ class pbis::params {
   $require_membership_of = undef
   $skeleton_dirs         = '/etc/skel'
   $user_domain_prefix    = undef
+  $nss_enumeration_enabled = undef
+  $cache_expiry          = 14400
 
   if !( $::architecture in ['amd64', 'x86_64', 'i386'] ) {
     fail("Unsupported architecture: ${::architecture}.")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -22,7 +22,7 @@ class pbis::params {
   $require_membership_of = undef
   $skeleton_dirs         = '/etc/skel'
   $user_domain_prefix    = undef
-  $nss_enumeration_enabled = undef
+  $nss_enumeration_enabled = true
   $cache_expiry          = 14400
 
   if !( $::architecture in ['amd64', 'x86_64', 'i386'] ) {

--- a/templates/pbis.conf.erb
+++ b/templates/pbis.conf.erb
@@ -8,5 +8,7 @@ HomeDirUmask "<%= home_dir_umask -%>"
 LoginShellTemplate "<%= login_shell_template -%>"
 SkeletonDirs "<%= skeleton_dirs -%>"
 UserDomainPrefix "<%= user_domain_prefix -%>"
+NssEnumerationEnabled "<%= nss_enumeration_enabled -%>"
+CacheEntryExpiry "<%= cache_expiry -%>"
 <% if @require_membership_of -%>RequireMembershipOf "<%= require_membership_of -%>"<% end -%>
 


### PR DESCRIPTION
Added handling for nss_enumeration and CacheEntryExpiry
Use this for environments where we need to keep AD cache expiry longer than normal - default 4 hours , override with hiera data to got to max 1 day
